### PR TITLE
Update package build (and other minor bugs)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name='tap-criteo',
       packages=find_packages(),
       package_data={
           'tap_criteo': [
-              'schemas/*.json'
+              'schemas/*.json',
+              'metadata/*.json'
           ]
       })

--- a/tap_criteo/__init__.py
+++ b/tap_criteo/__init__.py
@@ -24,7 +24,7 @@ def main():
         print(json.dumps(catalog, indent=2))
     # Otherwise run in sync mode
     elif args.catalog:
-        do_sync(args.config, args.state, catalog)
+        do_sync(args.config, args.state, args.catalog)
 
 
 if __name__ == "__main__":

--- a/tap_criteo/sync.py
+++ b/tap_criteo/sync.py
@@ -277,7 +277,7 @@ def sync_statistics_for_day(
         "metrics": report_metrics,
         "start_date": start.strftime("%Y-%m-%d"),
         "end_date": start.strftime("%Y-%m-%d"),
-        "currency": metadata.get(mdata, (), "currency"),
+        "currency": metadata.get(mdata, (), "tap-criteo.currency"),
     }
     # Filter advertiser_ids if defined in config
     advertiser_ids = config.get("advertiser_ids")
@@ -300,7 +300,7 @@ def sync_statistics_for_day(
             for row in csv_reader:
                 row["_sdc_report_datetime"] = REPORT_RUN_DATETIME
                 row["_sdc_report_currency"] = metadata.get(
-                    mdata, (), "currency"
+                    mdata, (), "tap-criteo.currency"
                 )
                 row = bumble_bee.transform(row, stream.schema.to_dict())
 

--- a/tap_criteo/sync.py
+++ b/tap_criteo/sync.py
@@ -243,7 +243,7 @@ def sync_statistics_report(config, state, stream, sdk_client, token):
             state,
             state_key_name(advertiser_ids, stream.stream),
             "last_attribution_window_date",
-            start_date.strftime(utils.DATETIME_FMT),
+            utils.strftime(start_date),
         )
         singer.write_state(state)
     bookmarks.clear_bookmark(
@@ -323,7 +323,7 @@ def sync_statistics_for_day(
                 state,
                 state_key_name(advertiser_ids, stream.stream),
                 "date",
-                start.strftime(utils.DATETIME_FMT),
+                utils.strftime(start),
             )
             singer.write_state(state)
         else:


### PR DESCRIPTION
# Description of change
Fixes #4 -- updating the package build to include the metadata files. 

I included a few small fixes for bugs I ran into trying to get the PyPI package to run so it should run with normal use, including fixing runs using the catalog generated by discovery mode. It looks like the metadata naming convention was changed previously, so to get it working without these changes I had to manually update the metadata references in the generated catalog to use `currency` instead of `tap-criteo.currency`. The catalog itself also wasn't referenced correctly when it was provided as an argument, and it was saving the bookmark in `state.json` with an incorrect format that made subsequent runs after the first fail.

# Manual QA steps
 - Run `python3 setup.py sdist bdist_wheel` and ensure `build/lib/tap_criteo/metadata` exists. 
 - Run discovery `python3 -m tap_criteo.__init__ -c ../criteo_config.json --discover > catalog.json`
 - Run `python3 -m tap_criteo.__init__ -c ../criteo_config.json --catalog ../catalog.json --state ../state.json | ../virtualenv/target-csv/bin/target-csv` and ensure output contains fields as expected. 
 
# Risks
 - Can't fully test the built distribution
 
# Rollback steps
 - Revert this branch
